### PR TITLE
Sometimes 'event' key is empty, so we won't fail

### DIFF
--- a/src/MandrillWebhookController.php
+++ b/src/MandrillWebhookController.php
@@ -22,11 +22,14 @@ class MandrillWebhookController extends Controller
 
         foreach ($events as $event) {
 
-            $method = 'handle' . studly_case(str_replace('.', '_', $event['event']));
-
-            if ( method_exists($this, $method) ) {
-                $this->{$method}($event);
+            if(!empty($event['event'])) {
+                $method = 'handle' . studly_case(str_replace('.', '_', $event['event']));
+    
+                if ( method_exists($this, $method) ) {
+                    $this->{$method}($event);
+                }
             }
+            
         }
 
         return new Response;


### PR DESCRIPTION
When testing our webhook URL, Mandrill sends a POST with an empty 'events' array, which leads to a 500 error if we don't handle it.
