### PR TITLE
Check for 'event' key existence before handling it

### DIFF
--- a/src/MandrillWebhookController.php
+++ b/src/MandrillWebhookController.php
@@ -22,11 +22,13 @@ class MandrillWebhookController extends Controller
 
         foreach ($events as $event) {
 
-            $method = 'handle' . studly_case(str_replace('.', '_', $event['event']));
+            $method = isset($event['event']) ? 
+                'handle' . studly_case(str_replace('.', '_', $event['event'])) : 'Undefined';
 
             if ( method_exists($this, $method) ) {
                 $this->{$method}($event);
             }
+            
         }
 
         return new Response;


### PR DESCRIPTION
Instead of checking it inside a if(){ ... } block, now we are setting the $method variable as 'Undefined' if the event is not set, so developers could handle it if they want, using handleUndefined() method.
