### PR TITLE
Now it's done right. ;)

### DIFF
--- a/src/MandrillWebhookController.php
+++ b/src/MandrillWebhookController.php
@@ -22,7 +22,8 @@ class MandrillWebhookController extends Controller
 
         foreach ($events as $event) {
 
-            $method = 'handle' . studly_case(str_replace('.', '_', $event['event']));
+            $eventName = isset($event['event']) ? $event['event'] : 'undefined';
+            $method = 'handle' . studly_case(str_replace('.', '_', $eventName));
 
             if ( method_exists($this, $method) ) {
                 $this->{$method}($event);


### PR DESCRIPTION
You can reproduce the "undefined" event by adding a new Webhook in mandrill and clicking "Test". They'll send a POST request with an empty event.

I don't know if there are another situation that they'll send empty events.
